### PR TITLE
Sanitize coef and FE names

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,22 +102,6 @@ then use `\input` in LaTeX to include that file in your code. Be sure to use the
 \end{document}
 ```
 
-In order to escape forbidden LaTeX characters, use code like the following.
-
-```julia
-repl_dict = Dict("_" => "\\_", "&" => "\\&")
-
-function sanitize(s, repl_dict=repl_dict)
-  for (old, new) in repl_dict
-    s = replace.(s, Ref(old => new))
-  end
-  
-  s
-end
-
-regtable(rr1,rr2,rr3,rr4; renderSettings = latexOutput(), sanitize_labels = sanitize)
-```
-
 `regtable()` can also print `DataFrameRegressionModel`'s from [GLM.jl](https://github.com/JuliaStats/GLM.jl):
 ```julia
 dobson = DataFrame(Counts = [18.,17,15,20,10,20,25,13,12],
@@ -176,6 +160,20 @@ R2                0.014      0.014
 * `standardize_coef` is a `Bool` that governs whether the table should show standardized coefficients. Note that this only works with `DataFrameRegressionModel`s, and that only coefficient estimates and the `below_statistic` are being standardized (i.e. the R^2 etc still pertain to the non-standardized regression).
 * `out_buffer` is an `IOBuffer` that the output gets sent to (unless an output file is specified, in which case the output is only sent to the file).
 * `renderSettings::RenderSettings` is a `RenderSettings` composite type that governs how the table should be rendered. Standard supported types are ASCII (via `asciiOutput(outfile::String)`) and LaTeX (via `latexOutput(outfile::String)`). If no argument to these two functions are given, the output is sent to STDOUT. Defaults to ASCII with STDOUT.
+* `transform_labels` is a function that is used to transform labels. In order to escape forbidden LaTeX characters use
+    ```julia
+    repl_dict = Dict("&" => "\\&", "%" => "\\%", "$" => "\\$", "#" => "\\#", "_" => "\\_", "{" => "\\{", "}" => "\\}") 
+    function sanitize(s, repl_dict=repl_dict)
+        for (old, new) in repl_dict
+            s = replace.(s, Ref(old => new))
+        end
+        s
+    end
+    
+    regtable(rr1,rr2,rr3,rr4; renderSettings = latexOutput(), sanitize_labels = sanitize)
+    ```
+    Defaults to `identity`.
+
 
 ### Label Codes
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,23 @@ then use `\input` in LaTeX to include that file in your code. Be sure to use the
 
 \end{document}
 ```
+
+In order to escape forbidden LaTeX characters, use code like the following.
+
+```julia
+repl_dict = Dict("_" => "\\_", "&" => "\\&")
+
+function sanitize(s, repl_dict=repl_dict)
+  for (old, new) in repl_dict
+    s = replace.(s, Ref(old => new))
+  end
+  
+  s
+end
+
+regtable(rr1,rr2,rr3,rr4; renderSettings = latexOutput(), sanitize_labels = sanitize)
+```
+
 `regtable()` can also print `DataFrameRegressionModel`'s from [GLM.jl](https://github.com/JuliaStats/GLM.jl):
 ```julia
 dobson = DataFrame(Counts = [18.,17,15,20,10,20,25,13,12],

--- a/README.md
+++ b/README.md
@@ -163,14 +163,14 @@ R2                0.014      0.014
 * `transform_labels` is a function that is used to transform labels. In order to escape forbidden LaTeX characters use
     ```julia
     repl_dict = Dict("&" => "\\&", "%" => "\\%", "$" => "\\$", "#" => "\\#", "_" => "\\_", "{" => "\\{", "}" => "\\}") 
-    function sanitize(s, repl_dict=repl_dict)
+    function transform(s, repl_dict=repl_dict)
         for (old, new) in repl_dict
             s = replace.(s, Ref(old => new))
         end
         s
     end
     
-    regtable(rr1,rr2,rr3,rr4; renderSettings = latexOutput(), sanitize_labels = sanitize)
+    regtable(rr1,rr2,rr3,rr4; renderSettings = latexOutput(), transform_labels = transform)
     ```
     Defaults to `identity`.
 

--- a/src/regtable.jl
+++ b/src/regtable.jl
@@ -84,7 +84,8 @@ function regtable(rr::Union{AbstractRegressionResult,DataFrameRegressionModel}..
     print_estimator_section = true,
     standardize_coef = false,
     out_buffer = IOBuffer(),
-    renderSettings::RenderSettings = asciiOutput()
+    sanitize_labels::Function = identity,
+    renderSettings::RenderSettings = asciiOutput()    
     )
 
     # define some functions that makes use of StatsModels' RegressionModels
@@ -181,7 +182,7 @@ function regtable(rr::Union{AbstractRegressionResult,DataFrameRegressionModel}..
            @warn("Regressor $regressor not found among regression results.")
         else
             # add label on the left:
-            estimateLine[1,1] = haskey(labels,regressor) ? labels[regressor] : regressor
+            estimateLine[1,1] = haskey(labels,regressor) ? labels[regressor] : sanitize_labels(regressor)
             # add to estimateBlock
             estimateBlock = [estimateBlock; estimateLine]
         end
@@ -271,7 +272,7 @@ function regtable(rr::Union{AbstractRegressionResult,DataFrameRegressionModel}..
                @warn("Fixed effect $fe not found in any regression results.")
             else
                 # add label on the left:
-                feLine[1,1] = haskey(labels,fe) ? labels[fe] : fe
+                feLine[1,1] = haskey(labels,fe) ? labels[fe] : sanitize_labels(fe)
                 # add to estimateBlock
                 feBlock = [feBlock; feLine]
             end

--- a/src/regtable.jl
+++ b/src/regtable.jl
@@ -84,7 +84,7 @@ function regtable(rr::Union{AbstractRegressionResult,DataFrameRegressionModel}..
     print_estimator_section = true,
     standardize_coef = false,
     out_buffer = IOBuffer(),
-    sanitize_labels::Function = identity,
+    transform_labels::Function = identity,
     renderSettings::RenderSettings = asciiOutput()    
     )
 
@@ -182,7 +182,7 @@ function regtable(rr::Union{AbstractRegressionResult,DataFrameRegressionModel}..
            @warn("Regressor $regressor not found among regression results.")
         else
             # add label on the left:
-            estimateLine[1,1] = haskey(labels,regressor) ? labels[regressor] : sanitize_labels(regressor)
+            estimateLine[1,1] = haskey(labels,regressor) ? labels[regressor] : transform_labels(regressor)
             # add to estimateBlock
             estimateBlock = [estimateBlock; estimateLine]
         end
@@ -193,7 +193,7 @@ function regtable(rr::Union{AbstractRegressionResult,DataFrameRegressionModel}..
     regressandBlock = fill("", 1, numberOfResults+1)
     for rIndex = 1:numberOfResults
         # keep in mind that yname is a Symbol
-        regressandBlock[1,rIndex+1] = haskey(labels,string(yname(rr[rIndex]))) ? labels[string(yname(rr[rIndex]))] : sanitize_labels(string(yname(rr[rIndex])))
+        regressandBlock[1,rIndex+1] = haskey(labels,string(yname(rr[rIndex]))) ? labels[string(yname(rr[rIndex]))] : transform_labels(string(yname(rr[rIndex])))
     end
 
     # Regression numbering block (if we do it)
@@ -272,7 +272,7 @@ function regtable(rr::Union{AbstractRegressionResult,DataFrameRegressionModel}..
                @warn("Fixed effect $fe not found in any regression results.")
             else
                 # add label on the left:
-                feLine[1,1] = haskey(labels,fe) ? labels[fe] : sanitize_labels(fe)
+                feLine[1,1] = haskey(labels,fe) ? labels[fe] : transform_labels(fe)
                 # add to estimateBlock
                 feBlock = [feBlock; feLine]
             end

--- a/src/regtable.jl
+++ b/src/regtable.jl
@@ -193,7 +193,7 @@ function regtable(rr::Union{AbstractRegressionResult,DataFrameRegressionModel}..
     regressandBlock = fill("", 1, numberOfResults+1)
     for rIndex = 1:numberOfResults
         # keep in mind that yname is a Symbol
-        regressandBlock[1,rIndex+1] = haskey(labels,string(yname(rr[rIndex]))) ? labels[string(yname(rr[rIndex]))] : string(yname(rr[rIndex]))
+        regressandBlock[1,rIndex+1] = haskey(labels,string(yname(rr[rIndex]))) ? labels[string(yname(rr[rIndex]))] : sanitize_labels(string(yname(rr[rIndex])))
     end
 
     # Regression numbering block (if we do it)


### PR DESCRIPTION
Solves #18.

```julia
repl_dict = Dict("_" => "\\_", "&" => "\\&")

function sanitize(s, repl_dict=repl_dict)
  for (old, new) in repl_dict
    s = replace.(s, Ref(old => new))
  end
  
  s
end

regtable(rr1,rr2,rr3,rr4; renderSettings = latexOutput(), sanitize_labels = sanitize)
```

One could think of defining a default sanitizer for LaTeX rendering. There might be lists of forbidden characters somewhere.

What do you think?