### PR TITLE
Latex transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ R2                0.014      0.014
 * `standardize_coef` is a `Bool` that governs whether the table should show standardized coefficients. Note that this only works with `DataFrameRegressionModel`s, and that only coefficient estimates and the `below_statistic` are being standardized (i.e. the R^2 etc still pertain to the non-standardized regression).
 * `out_buffer` is an `IOBuffer` that the output gets sent to (unless an output file is specified, in which case the output is only sent to the file).
 * `renderSettings::RenderSettings` is a `RenderSettings` composite type that governs how the table should be rendered. Standard supported types are ASCII (via `asciiOutput(outfile::String)`) and LaTeX (via `latexOutput(outfile::String)`). If no argument to these two functions are given, the output is sent to STDOUT. Defaults to ASCII with STDOUT.
-* `transform_labels` is a function that is used to transform labels. In order to escape forbidden LaTeX characters use
+* `transform_labels` is a function that is used to transform labels. For example, in order to escape certain LaTeX characters, use
     ```julia
-    repl_dict = Dict("&" => "\\&", "%" => "\\%", "$" => "\\$", "#" => "\\#", "_" => "\\_", "{" => "\\{", "}" => "\\}") 
+    repl_dict = Dict("&" => "\\&", "%" => "\\%", "\$" => "\\\$", "#" => "\\#", "_" => "\\_", "{" => "\\{", "}" => "\\}") 
     function transform(s, repl_dict=repl_dict)
         for (old, new) in repl_dict
             s = replace.(s, Ref(old => new))
@@ -170,9 +170,9 @@ R2                0.014      0.014
         s
     end
     
-    regtable(rr1,rr2,rr3,rr4; renderSettings = latexOutput(), transform_labels = transform)
+    regtable(rr; renderSettings = latexOutput(), transform_labels = transform)
     ```
-    Defaults to `identity`.
+    Defaults to `identity`. The most common use case is probably to escape the ampersand `&` in LaTeX, which is already implemented as `transform_labels = escape_ampersand`.
 
 
 ### Label Codes

--- a/src/RegressionTables.jl
+++ b/src/RegressionTables.jl
@@ -71,6 +71,7 @@ module RegressionTables
     include("rendersettings/ascii.jl")
     include("rendersettings/latex.jl")
     include("rendersettings/html.jl")
+    include("label_transforms/default_transforms.jl")
 
     # main functions
     include("render.jl")

--- a/src/RegressionTables.jl
+++ b/src/RegressionTables.jl
@@ -51,7 +51,7 @@ module RegressionTables
     ##
     ##############################################################################
 
-    export regtable, latexOutput, asciiOutput, htmlOutput, RenderSettings
+    export regtable, latexOutput, asciiOutput, htmlOutput, RenderSettings, escape_ampersand
 
     ##############################################################################
     ##

--- a/src/label_transforms/default_transforms.jl
+++ b/src/label_transforms/default_transforms.jl
@@ -1,0 +1,8 @@
+# this function escapes the ampersand, which is probably the most common use case
+function escape_ampersand(s::String)
+    repl_dict = Dict("&" => "\\&") 
+    for (old, new) in repl_dict
+        s = replace.(s, Ref(old => new))
+    end
+    return s
+end

--- a/src/regtable.jl
+++ b/src/regtable.jl
@@ -20,6 +20,7 @@ Produces a publication-quality regression table, similar to Stata's `esttab` and
 * `standardize_coef` is a `Bool` that governs whether the table should show standardized coefficients. Note that this only works with `DataFrameRegressionModel`s, and that only coefficient estimates and the `below_statistic` are being standardized (i.e. the R^2 etc still pertain to the non-standardized regression).
 * `out_buffer` is an `IOBuffer` that the output gets sent to (unless an output file is specified, in which case the output is only sent to the file).
 * `renderSettings::RenderSettings` is a `RenderSettings` composite type that governs how the table should be rendered. Standard supported types are ASCII (via `asciiOutput(outfile::String)`) and LaTeX (via `latexOutput(outfile::String)`). If no argument to these two functions are given, the output is sent to STDOUT. Defaults to ASCII with STDOUT.
+* `transform_labels` is a `Function` that is used to transform labels. It takes the `String` to be transformed as an argument. See `README.md` for an example.
 
 ### Details
 A typical use is to pass a number of `AbstractRegressionResult`s to the function, along with a `RenderSettings` object.

--- a/test/RegressionTables.jl
+++ b/test/RegressionTables.jl
@@ -19,6 +19,7 @@ dobson = DataFrame(Counts = [18.,17,15,20,10,20,25,13,12],
 
 lm1 = fit(LinearModel, @formula(SepalLength ~ SepalWidth), df)
 lm2 = fit(LinearModel, @formula(SepalLength ~ SepalWidth + PetalWidth), df)
+lm3 = fit(LinearModel, @formula(SepalLength ~ SepalWidth * PetalWidth), df) # testing interactions
 gm1 = fit(GeneralizedLinearModel, @formula(Counts ~ 1 + Outcome), dobson,
               Poisson())
 
@@ -128,6 +129,9 @@ regtable(rr1,rr2,rr3,rr5; renderSettings = latexOutput(joinpath(dirname(@__FILE_
 
 regtable(lm1, lm2, gm1; renderSettings = latexOutput(joinpath(dirname(@__FILE__), "tables", "test4.tex")), regression_statistics = [:nobs, :r2])
 @test checkfilesarethesame(joinpath(dirname(@__FILE__), "tables", "test4.tex"), joinpath(dirname(@__FILE__), "tables", "test4_reference.tex"))
+
+regtable(lm1, lm2, lm3, gm1; renderSettings = latexOutput(joinpath(dirname(@__FILE__), "tables", "test6.tex")), regression_statistics = [:nobs, :r2], transform_labels = escape_ampersand)
+@test checkfilesarethesame(joinpath(dirname(@__FILE__), "tables", "test6.tex"), joinpath(dirname(@__FILE__), "tables", "test6_reference.tex"))
 
 # HTML Tables
 regtable(rr1,rr2,rr3,rr5; renderSettings = htmlOutput(joinpath(dirname(@__FILE__), "tables", "test1.html")), regression_statistics = [:nobs, :r2, :adjr2, :r2_within, :f, :p, :f_kp, :p_kp, :dof])

--- a/test/tables/test6_reference.tex
+++ b/test/tables/test6_reference.tex
@@ -1,0 +1,25 @@
+\begin{tabular}{lrrrr}
+\toprule
+                         & \multicolumn{3}{c}{SepalLength} & \multicolumn{1}{c}{Counts} \\ 
+\cmidrule(lr){2-4} \cmidrule(lr){5-5} 
+                         &      (1) &      (2) &       (3) &                        (4) \\ 
+\midrule
+(Intercept)              & 6.526*** & 3.457*** &  3.130*** &                   3.045*** \\ 
+                         &  (0.479) &  (0.309) &   (0.574) &                    (0.126) \\ 
+SepalWidth               &   -0.223 & 0.399*** &   0.496** &                            \\ 
+                         &  (0.155) &  (0.091) &   (0.171) &                            \\ 
+PetalWidth               &          & 0.972*** &   1.291** &                            \\ 
+                         &          &  (0.052) &   (0.474) &                            \\ 
+SepalWidth \& PetalWidth &          &          &    -0.099 &                            \\ 
+                         &          &          &   (0.147) &                            \\ 
+Outcome: B               &          &          &           &                     -0.454 \\ 
+                         &          &          &           &                    (0.202) \\ 
+Outcome: C               &          &          &           &                     -0.293 \\ 
+                         &          &          &           &                    (0.193) \\ 
+\midrule
+Estimator                &      OLS &      OLS &       OLS &                         NL \\ 
+\midrule
+$N$                      &      150 &      150 &       150 &                          9 \\ 
+$R^2$                    &    0.014 &    0.707 &     0.708 &                            \\ 
+\bottomrule
+\end{tabular}


### PR DESCRIPTION
Fixes a typo in the readme example on `transform_labels` ($'s were not escaped). Implements `escape_ampersand`, which should be useful if you use interactions in GLM.jl and want to output to LaTeX. And adds a test for that.

Fixes #18.