### PR TITLE
Allow FixedEffectTerms coming from fixed effect terms

### DIFF
--- a/src/RegressionTables.jl
+++ b/src/RegressionTables.jl
@@ -36,7 +36,7 @@ module RegressionTables
     using Compat
 
     import Distributions: ccdf, FDist
-    import FixedEffectModels: FixedEffectModel, has_fe, has_iv, eachterm #AbstractRegressionResult, RegressionResult, RegressionResultIV, RegressionResultFE, RegressionResultFEIV
+    import FixedEffectModels: FixedEffectModel, has_fe, has_iv, eachterm, FixedEffectTerm #AbstractRegressionResult, RegressionResult, RegressionResultIV, RegressionResultFE, RegressionResultFEIV
     import Formatting: sprintf1
     import GLM: LinearModel
     import StatsModels: TableRegressionModel

--- a/src/util/util.jl
+++ b/src/util/util.jl
@@ -21,3 +21,6 @@ end
 function name(t::FunctionTerm)
     string(t.args_parsed[1].sym)
 end
+function name(t::FixedEffectTerm)
+    string(t.x)
+end


### PR DESCRIPTION
Programatically created fixed effects come as FixedEffectTerms as I realized in  #51. For this type, no name function was defined. That's my first shot;-)