### PR TITLE
Improve transform labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,20 +162,24 @@ R2                0.014      0.014
 * `standardize_coef` is a `Bool` that governs whether the table should show standardized coefficients. Note that this only works with `TableRegressionModel`s, and that only coefficient estimates and the `below_statistic` are being standardized (i.e. the R^2 etc still pertain to the non-standardized regression).
 * `out_buffer` is an `IOBuffer` that the output gets sent to (unless an output file is specified, in which case the output is only sent to the file).
 * `renderSettings::RenderSettings` is a `RenderSettings` composite type that governs how the table should be rendered. Standard supported types are ASCII (via `asciiOutput(outfile::String)`) and LaTeX (via `latexOutput(outfile::String)`). If no argument to these two functions are given, the output is sent to STDOUT. Defaults to ASCII with STDOUT.
-* `transform_labels` is a function that is used to transform labels. For example, in order to escape certain LaTeX characters, use
+* `transform_labels` is a function or a `Dict` that is used to transform labels. Defaults to `identity`.
+
+    Some common use cases can be achieved by passing a `Symbol` instead: `:latex`, `:ampersand`, `:ampersand2space`, `:underscore`. For illustration, here are the three ways to escape forbidden LaTeX characters.
     ```julia
+    # Option 1
+    regtable(rr; renderSettings = latexOutput(), transform_labels = :latex)
+    # Option 2
     repl_dict = Dict("&" => "\\&", "%" => "\\%", "\$" => "\\\$", "#" => "\\#", "_" => "\\_", "{" => "\\{", "}" => "\\}")
+    regtable(rr; renderSettings = latexOutput(), transform_labels = repl_dict)
+    # Option 3
     function transform(s, repl_dict=repl_dict)
         for (old, new) in repl_dict
             s = replace.(s, Ref(old => new))
         end
         s
     end
-
     regtable(rr; renderSettings = latexOutput(), transform_labels = transform)
     ```
-    Defaults to `identity`. The most common use case is probably to escape the ampersand `&` in LaTeX, which is already implemented as `transform_labels = escape_ampersand`.
-
 
 ### Label Codes
 

--- a/src/label_transforms/default_transforms.jl
+++ b/src/label_transforms/default_transforms.jl
@@ -1,8 +1,26 @@
-# this function escapes the ampersand, which is probably the most common use case
-function escape_ampersand(s::String)
-    repl_dict = Dict("&" => "\\&") 
-    for (old, new) in repl_dict
-        s = replace.(s, Ref(old => new))
+function _escape(repl_dict::AbstractDict)
+    function escape(s::String)  
+        for (old, new) in repl_dict
+            s = replace.(s, Ref(old => new))
+        end
+        return s
     end
-    return s
 end
+
+escape_latex_dict = Dict("&" => "\\&", "%" => "\\%", "\$" => "\\\$", "#" => "\\#", "_" => "\\_", "{" => "\\{", "}" => "\\}")
+
+function _escape(s::Symbol)
+  if s == :ampersand
+    _escape(Dict("&" => "\\&"))
+  elseif s == :underscore
+    _escape(Dict("_" => "\\_"))
+  elseif s == :underscore2space
+    _escape(Dict("_" => " "))  
+  elseif s == :latex
+    _escape(escape_latex_dict)
+  else
+    @error "Please provide `:ampersand`, `:underscore`, `:underscore2space`, `:latex`, a `::Dict` or a custom function."
+  end
+end
+
+

--- a/src/regtable.jl
+++ b/src/regtable.jl
@@ -21,7 +21,7 @@ Produces a publication-quality regression table, similar to Stata's `esttab` and
 * `standardize_coef` is a `Bool` that governs whether the table should show standardized coefficients. Note that this only works with `TableRegressionModel`s, and that only coefficient estimates and the `below_statistic` are being standardized (i.e. the R^2 etc still pertain to the non-standardized regression).
 * `out_buffer` is an `IOBuffer` that the output gets sent to (unless an output file is specified, in which case the output is only sent to the file).
 * `renderSettings::RenderSettings` is a `RenderSettings` composite type that governs how the table should be rendered. Standard supported types are ASCII (via `asciiOutput(outfile::String)`) and LaTeX (via `latexOutput(outfile::String)`). If no argument to these two functions are given, the output is sent to STDOUT. Defaults to ASCII with STDOUT.
-* `transform_labels` is a `Function` that is used to transform labels. It takes the `String` to be transformed as an argument. See `README.md` for an example. XXX
+* `transform_labels` is a `Function`, a `Dict` or one of the `Symbol`s `:ampersand`, `:underscore`, `:underscore2space`, `:latex`. See `README.md` for examples.
 
 ### Details
 A typical use is to pass a number of `FixedEffectModel`s to the function, along with a `RenderSettings` object.

--- a/src/regtable.jl
+++ b/src/regtable.jl
@@ -21,7 +21,7 @@ Produces a publication-quality regression table, similar to Stata's `esttab` and
 * `standardize_coef` is a `Bool` that governs whether the table should show standardized coefficients. Note that this only works with `TableRegressionModel`s, and that only coefficient estimates and the `below_statistic` are being standardized (i.e. the R^2 etc still pertain to the non-standardized regression).
 * `out_buffer` is an `IOBuffer` that the output gets sent to (unless an output file is specified, in which case the output is only sent to the file).
 * `renderSettings::RenderSettings` is a `RenderSettings` composite type that governs how the table should be rendered. Standard supported types are ASCII (via `asciiOutput(outfile::String)`) and LaTeX (via `latexOutput(outfile::String)`). If no argument to these two functions are given, the output is sent to STDOUT. Defaults to ASCII with STDOUT.
-* `transform_labels` is a `Function` that is used to transform labels. It takes the `String` to be transformed as an argument. See `README.md` for an example.
+* `transform_labels` is a `Function` that is used to transform labels. It takes the `String` to be transformed as an argument. See `README.md` for an example. XXX
 
 ### Details
 A typical use is to pass a number of `FixedEffectModel`s to the function, along with a `RenderSettings` object.
@@ -89,10 +89,12 @@ function regtable(rr::Union{FixedEffectModel,TableRegressionModel}...;
     print_estimator_section = true,
     standardize_coef = false,
     out_buffer = IOBuffer(),
-    transform_labels::Function = identity,
+    transform_labels::Union{Dict,Function,Symbol} = identity,
     renderSettings::RenderSettings = asciiOutput()
     )
-
+    
+    _transform_labels = transform_labels isa Function ? transform_labels : _escape(transform_labels)
+      
     # define some functions that makes use of StatsModels' RegressionModels
     coefnames(r::TableRegressionModel) = StatsModels.coefnames(r.mf)
     coefnames(r::FixedEffectModel) = String.(r.coefnames) # this will need to be updated when we move
@@ -188,7 +190,7 @@ function regtable(rr::Union{FixedEffectModel,TableRegressionModel}...;
            @warn("Regressor $(String(regressor)) not found among regression results.")
         else
             # add label on the left:
-            estimateLine[1,1] = haskey(labels,regressor) ? labels[regressor] : transform_labels(regressor)
+            estimateLine[1,1] = haskey(labels,regressor) ? labels[regressor] : _transform_labels(regressor)
             # add to estimateBlock
             estimateBlock = [estimateBlock; estimateLine]
         end
@@ -199,7 +201,7 @@ function regtable(rr::Union{FixedEffectModel,TableRegressionModel}...;
     regressandBlock = fill("", 1, numberOfResults+1)
     for rIndex = 1:numberOfResults
         # keep in mind that yname is a Symbol
-        regressandBlock[1,rIndex+1] = haskey(labels,string(yname(rr[rIndex]))) ? labels[string(yname(rr[rIndex]))] : transform_labels(string(yname(rr[rIndex])))
+        regressandBlock[1,rIndex+1] = haskey(labels,string(yname(rr[rIndex]))) ? labels[string(yname(rr[rIndex]))] : _transform_labels(string(yname(rr[rIndex])))
     end
     
     if length(groups) > 0
@@ -308,7 +310,7 @@ function regtable(rr::Union{FixedEffectModel,TableRegressionModel}...;
                @warn("Fixed effect $fe not found in any regression results.")
             else
                 # add label on the left:
-                feLine[1,1] = haskey(labels,name(fe)) ? labels[name(fe)] : transform_labels(name(fe))
+                feLine[1,1] = haskey(labels,name(fe)) ? labels[name(fe)] : _transform_labels(name(fe))
                 # add to estimateBlock
                 feBlock = [feBlock; feLine]
             end
@@ -439,3 +441,4 @@ function regtable(rr::Union{FixedEffectModel,TableRegressionModel}...;
     end
 
 end
+

--- a/src/regtable.jl
+++ b/src/regtable.jl
@@ -205,7 +205,8 @@ function regtable(rr::Union{FixedEffectModel,TableRegressionModel}...;
     end
     
     if length(groups) > 0
-        regressandBlock = ["" reshape(groups, 1, numberOfResults);
+        groupBlock = reshape(string.(groups), :, numberOfResults) .|> _transform_labels
+        regressandBlock = [fill("", size(groupBlock, 1)) groupBlock;
                            regressandBlock]
     end
     

--- a/test/RegressionTables.jl
+++ b/test/RegressionTables.jl
@@ -161,7 +161,7 @@ RegressionTables.regtable(rr3,rr5,lm1, lm2, gm1; renderSettings = RegressionTabl
 RegressionTables.regtable(rr3,rr5,lm1, lm2, gm1; renderSettings = RegressionTables.asciiOutput(joinpath(dirname(@__FILE__), "tables", "ftest5.txt")), print_fe_section = false, print_estimator_section = false)
 @test checkfilesarethesame(joinpath(dirname(@__FILE__), "tables", "ftest5.txt"), joinpath(dirname(@__FILE__), "tables", "ftest5_reference.txt"))
 # transform_labels and custom labels
-RegressionTables.regtable(rr5,rr6,lm1, lm2, lm3; renderSettings = RegressionTables.asciiOutput(joinpath(dirname(@__FILE__), "tables", "ftest6.txt")), regression_statistics = [:nobs, :r2, :adjr2, :r2_within, :f, :p, :f_kp, :p_kp, :dof], transform_labels = RegressionTables.escape_ampersand,
+RegressionTables.regtable(rr5,rr6,lm1, lm2, lm3; renderSettings = RegressionTables.asciiOutput(joinpath(dirname(@__FILE__), "tables", "ftest6.txt")), regression_statistics = [:nobs, :r2, :adjr2, :r2_within, :f, :p, :f_kp, :p_kp, :dof], transform_labels = :ampersand,
 labels = Dict("SepalLength" => "My dependent variable: SepalLength", "PetalLength" => "Length of Petal", "PetalWidth" => "Width of Petal", "(Intercept)" => "Const." , "isSmall" => "isSmall Dummies", "SpeciesDummy" => "Species Dummies"))
 @test checkfilesarethesame(joinpath(dirname(@__FILE__), "tables", "ftest6.txt"), joinpath(dirname(@__FILE__), "tables", "ftest6_reference.txt"))
 # grouped regressions PR #61
@@ -222,7 +222,7 @@ regtable(rr1,rr2,rr3,rr5; renderSettings = latexOutput(joinpath(dirname(@__FILE_
 regtable(lm1, lm2, gm1; renderSettings = latexOutput(joinpath(dirname(@__FILE__), "tables", "test4.tex")), regression_statistics = [:nobs, :r2])
 @test checkfilesarethesame(joinpath(dirname(@__FILE__), "tables", "test4.tex"), joinpath(dirname(@__FILE__), "tables", "test4_reference.tex"))
 
-regtable(lm1, lm2, lm3, gm1; renderSettings = latexOutput(joinpath(dirname(@__FILE__), "tables", "test6.tex")), regression_statistics = [:nobs, :r2], transform_labels = escape_ampersand)
+regtable(lm1, lm2, lm3, gm1; renderSettings = latexOutput(joinpath(dirname(@__FILE__), "tables", "test6.tex")), regression_statistics = [:nobs, :r2], transform_labels = :ampersand)
 @test checkfilesarethesame(joinpath(dirname(@__FILE__), "tables", "test6.tex"), joinpath(dirname(@__FILE__), "tables", "test6_reference.tex"))
 
 # HTML Tables

--- a/test/label_transforms.jl
+++ b/test/label_transforms.jl
@@ -1,0 +1,17 @@
+using RegressionTables: _escape
+using Test
+@testset "label transforms" begin
+  # ampersand
+  @test _escape(:ampersand)("X1 & X2") == "X1 \\& X2"
+  
+  # underscores
+  @test _escape(:underscore2space)("long_var") == "long var"
+  @test _escape(:underscore)("long_var") == "long\\_var"
+  
+  # latex
+  @test _escape(:latex)("& % \$ # _ { }") == "\\& \\% \\\$ \\# \\_ \\{ \\}"
+  
+  # Dictionary
+  @test _escape(Dict("bla" => "blaaaa"))("bla bla bla") == "blaaaa blaaaa blaaaa"
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
 using RegressionTables
 
 tests = ["RegressionTables.jl",
-				 "decorations.jl"
+				 "decorations.jl",
+				 "label_transforms.jl"
 		 ]
 
 println("Running tests:")


### PR DESCRIPTION
This now allows passing a transformator `Function` (like before), a `Dict`, or one of the keywords `:ampersand`, `: underscore`, `:underscore2space`, `:latex`.

This is breaking, since we don't allow `transform_labels=escape_ampersand` anymore. 

Do you think a deprecation is necessary? I've never done that though.