### PR TITLE
Add `groups` to the explanation of args of `regtable` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ R2                0.014      0.014
 * `custom_statistics` is a `NamedTuple` that takes user specified statistics to be shown just above `regression_statistics`. By default each statistic will be labelled by its key (e.g. `__LABEL_STATISTIC_mystat__` for the statistic `mystat`). Defaults to `missing`. See `test/RegressionTables.jl` for an example of how to use this.
 * `number_regressions` is a `Bool` that governs whether regressions should be numbered. Defaults to `true`.
 * `number_regressions_decoration` is a `Function` that governs the decorations to the regression numbers. Defaults to `s -> "($s)"`.
+* `groups` is a `Vector` of labels used to group regressions. This can be useful if results are shown for different data sets or sample restrictions. Defaults to `[]`.
 * `print_fe_section` is a `Bool` that governs whether a section on fixed effects should be shown. Defaults to `true`.
 * `print_estimator_section`  is a `Bool` that governs whether to print a section on which estimator (OLS/IV) is used. Defaults to `true`.
 * `standardize_coef` is a `Bool` that governs whether the table should show standardized coefficients. Note that this only works with `TableRegressionModel`s, and that only coefficient estimates and the `below_statistic` are being standardized (i.e. the R^2 etc still pertain to the non-standardized regression).


### PR DESCRIPTION
Fixed README has lacked the explanation of the argument `groups`  (Ref. #61).