### PR TITLE
Add option to use original coefficient names in arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Manifest.toml
 docs/build/
 docs/site/
+.vscode/

--- a/docs/src/keep_drop_order.md
+++ b/docs/src/keep_drop_order.md
@@ -105,33 +105,6 @@ Within-R2                       0.281      0.642      0.659        0.391
 ------------------------------------------------------------------------
 ```
 
-Note, if labels change the name of the arguments, then the `keep` argument would also need to change:
-```jldoctest
-regtable(rr1, rr2, rr3, rr4; labels=Dict("SepalWidth" => "SW", "PetalLength" => "PL"), keep=["SW", "PL"])
-
-# output
-
- 
----------------------------------------------------------------------
-                                       SepalLength               SW
-                             ------------------------------   -------
-                                  (1)        (2)        (3)       (4)
----------------------------------------------------------------------
-SW                           0.804***   0.432***   0.719***
-                              (0.106)    (0.081)    (0.155)
-PL                                      0.776***   1.047***   -0.188*
-                                         (0.064)    (0.143)   (0.083)
----------------------------------------------------------------------
-SpeciesDummy Fixed Effects        Yes        Yes        Yes       Yes
----------------------------------------------------------------------
-Controls                                                Yes       Yes
----------------------------------------------------------------------
-N                                 150        150        150       150
-R2                              0.726      0.863      0.870     0.635
-Within-R2                       0.281      0.642      0.659     0.391
----------------------------------------------------------------------
-```
-
 Interacted coefficients are selected using the `&` to separate the interactions, even if the settings use a different interaction. For example, in Latex, the interaction defaults to `\$times\$`, but would still be selected by using `&`:
 ```jldoctest
 regtable(rr1, rr2, rr3, rr4; render=LatexTable(), keep=["SepalWidth & PetalLength"])
@@ -402,4 +375,61 @@ N                                150         150
 R2                             0.867       0.863
 Within-R2                      0.652
 ------------------------------------------------
+```
+
+## Relabeled Coefficients
+
+By default, if labels change the name of the arguments, then `keep`, `drop` and `order` should use the relabeled versions of the coefficients. For example, if the coefficients are relabeled:
+
+```jldoctest
+regtable(rr1, rr2, rr3, rr4; labels=Dict("SepalWidth" => "SW", "PetalLength" => "PL"), keep=["SW", "PL"])
+
+# output
+
+ 
+---------------------------------------------------------------------
+                                       SepalLength               SW
+                             ------------------------------   -------
+                                  (1)        (2)        (3)       (4)
+---------------------------------------------------------------------
+SW                           0.804***   0.432***   0.719***
+                              (0.106)    (0.081)    (0.155)
+PL                                      0.776***   1.047***   -0.188*
+                                         (0.064)    (0.143)   (0.083)
+---------------------------------------------------------------------
+SpeciesDummy Fixed Effects        Yes        Yes        Yes       Yes
+---------------------------------------------------------------------
+Controls                                                Yes       Yes
+---------------------------------------------------------------------
+N                                 150        150        150       150
+R2                              0.726      0.863      0.870     0.635
+Within-R2                       0.281      0.642      0.659     0.391
+---------------------------------------------------------------------
+```
+
+To use the original coefficient names, set `use_relabeled_values=false`:
+```jldoctest
+regtable(rr1, rr2, rr3, rr4; labels=Dict("SepalWidth" => "SW", "PetalLength" => "PL"), keep=["SepalWidth", "PetalLength"], use_relabeled_values=false)
+
+# output
+
+ 
+------------------------------------------------------------------------
+                                       SepalLength            SepalWidth
+                             ------------------------------   ----------
+                                  (1)        (2)        (3)          (4)
+------------------------------------------------------------------------
+SW                           0.804***   0.432***   0.719***
+                              (0.106)    (0.081)    (0.155)
+PL                                      0.776***   1.047***      -0.188*
+                                         (0.064)    (0.143)      (0.083)
+------------------------------------------------------------------------
+SpeciesDummy Fixed Effects        Yes        Yes        Yes          Yes
+------------------------------------------------------------------------
+Controls                                                Yes          Yes
+------------------------------------------------------------------------
+N                                 150        150        150          150
+R2                              0.726      0.863      0.870        0.635
+Within-R2                       0.281      0.642      0.659        0.391
+------------------------------------------------------------------------
 ```


### PR DESCRIPTION
Related to #147 , sometimes it is easier/more consistent to use the original coefficient names in the `keep`, `drop`, and `order` arguments. This pull request adds an extra option `use_relabeled_variables` (defaults to true) to add this option.

The default to true is consistent with the current behavior, making this a non-breaking change.