### PR TITLE
Add option to specify format of regression statistics in front end

### DIFF
--- a/src/regtable.jl
+++ b/src/regtable.jl
@@ -781,10 +781,18 @@ function combine_other_statistics(
     hcat(nms, mat)
 end
 
-display_val(x::Pair) = last(x)
+Format.format(x::Type{<:AbstractRegressionStatistic}; kwargs...) = (rr -> (isnothing(value(x(rr))) ? nothing : format(value(x(rr)); kwargs...)), x)
+Format.cfmt(fmtstr::String, x::Type{<:AbstractRegressionStatistic}) = (rr -> (isnothing(value(x(rr))) ? nothing : cfmt(fmtstr, value(x(rr)))), x)
+Format.cfmt(fspec::Format.FmtSpec, x::Type{<:AbstractRegressionStatistic}) = (rr -> (isnothing(value(x(rr))) ? nothing : cfmt(fspec, value(x(rr)))), x)
+
+display_val(x::Pair) = display_val(last(x))
 display_val(x::Type) = x
-f_val(x::Pair) = first(x)
+display_val(x::Tuple) = display_val(last(x))
+display_val(x) = x
+f_val(x::Pair) = f_val(first(x))
 f_val(x::Type) = x
+f_val(x::Tuple) = f_val(first(x))
+f_val(x) = x
 """
     combine_statistics(tables, stats)
 


### PR DESCRIPTION
Following #160, allowing more formatting options on the front end would be useful and likely more intuitive. This request attempts to do this by creating anonymous functions in these cases. The result would be:
```julia
regtable(rr1, rr2, rr3, rr4; regression_statistics=[
    Nobs,
    format(R2; precision=6),
    format(AIC; precision=1, commas=true),
    format(AdjR2; precision=3) => "My R2"
])

-------------------------------------------------------------
                                   Sales
              -----------------------------------------------
                     (1)          (2)         (3)         (4)
-------------------------------------------------------------
(Intercept)   138.480***   133.068***    0.007***    0.007***
                 (1.427)      (2.868)     (0.000)     (0.000)
NDI             0.007***     0.007***   -0.000***   -0.000***
                 (0.000)      (0.001)     (0.000)     (0.000)
Price          -0.938***    -0.813***    0.000***    0.000***
                 (0.054)      (0.079)     (0.000)     (0.000)
NDI & Price                   -0.000*                 0.000**
                              (0.000)                 (0.000)
-------------------------------------------------------------
Estimator            OLS          OLS       Gamma       Gamma
-------------------------------------------------------------
N                  1,380        1,380       1,380       1,380
R2              0.208806     0.211517
AIC             13,077.1     13,074.3    12,662.8    12,656.1
My R2              0.208        0.210
-------------------------------------------------------------
```