### PR TITLE
Force `name` and `level` to be of type `string` in CategoricalCoefName, not some funny string type like `string7`.

### DIFF
--- a/src/coefnames.jl
+++ b/src/coefnames.jl
@@ -146,7 +146,7 @@ Base.repr(render::AbstractRenderType, x::RegressionTables.CategoricalCoefName; a
 struct CategoricalCoefName <: AbstractCoefName
     name::String
     level::String
-    CategoricalCoefName(name::String, level::String) = new(name, level)
+    CategoricalCoefName(name::String, level::String) = new( string(name), string(level))
 end
 
 value(x::CategoricalCoefName) = x.name

--- a/src/coefnames.jl
+++ b/src/coefnames.jl
@@ -146,7 +146,7 @@ Base.repr(render::AbstractRenderType, x::RegressionTables.CategoricalCoefName; a
 struct CategoricalCoefName <: AbstractCoefName
     name::String
     level::String
-    CategoricalCoefName(name::String, level::String) = new( string(name), string(level))
+    CategoricalCoefName(name::String, level::String) = new( String(name), String(level))
 end
 
 value(x::CategoricalCoefName) = x.name

--- a/src/coefnames.jl
+++ b/src/coefnames.jl
@@ -43,7 +43,7 @@ Used to store the name of a coefficient. This is used for `Term`, `ContinuousTer
 """
 struct CoefName <: AbstractCoefName
     name::String
-    CoefName(name::String) = new(name)
+    CoefName(name::AbstractString) = new(String(name))
 end
 
 value(x::CoefName) = x.name
@@ -146,7 +146,7 @@ Base.repr(render::AbstractRenderType, x::RegressionTables.CategoricalCoefName; a
 struct CategoricalCoefName <: AbstractCoefName
     name::String
     level::String
-    CategoricalCoefName(name::String, level::String) = new( String(name), String(level))
+    CategoricalCoefName(name::AbstractString, level::AbstractString) = new(String(name), String(level))
 end
 
 value(x::CategoricalCoefName) = x.name


### PR DESCRIPTION
This allows for `level`, in particular, to be one of the funny types of string that DataFrames uses for categorical variables - e.g. `string7`.