### PR TITLE
Switch to broadcasting to fix no length issue on rhs in formula

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegressionTables"
 uuid = "d519eb52-b820-54da-95a6-98e1306fdade"
 authors = ["Johannes Boehm <johannes.boehm@gmail.com>"]
-version = "0.7.6"
+version = "0.7.7"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/ext/RegressionTablesFixedEffectModelsExt.jl
+++ b/ext/RegressionTablesFixedEffectModelsExt.jl
@@ -28,15 +28,12 @@ function RegressionTables.other_stats(rr::FixedEffectModel, s::Symbol)
         if !isdefined(rr, :formula)
             return Dict{Symbol, Vector{Pair}}()
         end
-        rhs_itr = if isa(rr.formula.rhs, StatsModels.Term)
-            [rr.formula.rhs]
-        else
-            rr.formula.rhs
-        end
-
-        for t in rhs_itr
-            if has_fe(t)
-                push!(out, RegressionTables.FixedEffectCoefName(RegressionTables.get_coefname(t)))
+        fe_set = has_fe.(rr.formula.rhs)
+        for (i, v) in enumerate(fe_set)
+            if v && !isa(fe_set, Bool)
+                push!(out, RegressionTables.FixedEffectCoefName(RegressionTables.get_coefname(rr.formula.rhs[i])))
+            elseif v
+                push!(out, RegressionTables.FixedEffectCoefName(RegressionTables.get_coefname(rr.formula.rhs)))
             end
         end
         if length(out) > 0

--- a/ext/RegressionTablesGLFixedEffectModelsExt.jl
+++ b/ext/RegressionTablesGLFixedEffectModelsExt.jl
@@ -19,9 +19,12 @@ function RegressionTables.other_stats(rr::GLFixedEffectModel, s::Symbol)
         if !isdefined(rr, :formula)
             return Dict{Symbol, Vector{Pair}}()
         end
-        for t in rr.formula.rhs
-            if has_fe(t)
-                push!(out, RegressionTables.FixedEffectCoefName(RegressionTables.get_coefname(t)))
+        fe_set = has_fe.(rr.formula.rhs)
+        for (i, v) in enumerate(fe_set)
+            if v && !isa(fe_set, Bool)
+                push!(out, RegressionTables.FixedEffectCoefName(RegressionTables.get_coefname(rr.formula.rhs[i])))
+            elseif v
+                push!(out, RegressionTables.FixedEffectCoefName(RegressionTables.get_coefname(rr.formula.rhs)))
             end
         end
         if length(out) > 0

--- a/test/RegressionTables.jl
+++ b/test/RegressionTables.jl
@@ -65,6 +65,10 @@ function checkfilesarethesame(file1::String, file2::String)
 end
 
 ##
+rr_short = reg(df, @formula(SepalLength ~ log1p(SepalWidth)))
+tab = regtable(rr_short)
+@test tab[4, 1] == "log1p(SepalWidth)"
+
 
 
 tab = regtable(rr4,rr5,lm1, lm2, gm1; renderSettings = asciiOutput(joinpath(dirname(@__FILE__), "tables", "ftest1.txt")), regression_statistics = [:nobs, :r2, :adjr2, :r2_within, :f, :p, :f_kp, :p_kp, :dof])


### PR DESCRIPTION
As noted by #164, a single value in the RHS of formula can cause an error since the function cannot iterate that value to look for fixed effects. This attempts to fix that by relying on broadcasting instead.